### PR TITLE
Disable concurrent builds (and abort previous if any)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,6 +2,7 @@ pipeline {
 	options {
 		timeout(time: 90, unit: 'MINUTES')
 		buildDiscarder(logRotator(numToKeepStr:'5'))
+		disableConcurrentBuilds(abortPrevious: true)
 	}
   agent {
     kubernetes {


### PR DESCRIPTION
This is especially useful when a PR is being updated while a build is running. 
You end up with multiple builds running concurrently when you just don't 
care anymore about the previous ones.

See https://support.cloudbees.com/hc/en-us/articles/360034881371-How-can-I-abort-a-running-Pipeline-build-if-a-new-one-is-started-