### PR TITLE
[RelEng] Perform code freeze period check in GitHub workflow

### DIFF
--- a/.github/workflows/verifyFreezePeriod.yml
+++ b/.github/workflows/verifyFreezePeriod.yml
@@ -1,0 +1,12 @@
+# This workflow calls the Code-Freeze-Period check
+
+name: Check Code Freeze Period
+
+on:
+  pull_request:
+    branches: 
+     - 'master'
+
+jobs:
+  check-freeze-period:
+    uses: eclipse-platform/eclipse.platform.releng.aggregator/.github/workflows/verifyFreezePeriod.yml@master

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -116,21 +116,5 @@ spec:
 				}
 			}
 		}
-		stage('Check freeze period') {
-			when {
-				not {
-					branch 'master'
-				}
-			}
-			steps {
-				container('jnlp') {
-					sh "wget https://download.eclipse.org/eclipse/relengScripts/scripts/verifyFreezePeriod.sh"
-					sh "chmod +x verifyFreezePeriod.sh"
-					withCredentials([string(credentialsId: 'google-api-key', variable: 'GOOGLE_API_KEY')]) {
-						sh './verifyFreezePeriod.sh'
-					}
-				}
-			}
-		}
 	}
 }


### PR DESCRIPTION
Perform the code freeze period check in a dedicated reusable workflow instead of in the Jenkins-Build-Pipeline.

The workflow being called was created in:
https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/206

- [x] GH-Actions have to be enabled for this repository