### PR TITLE
Bump swt fragments versions to match host version.

### DIFF
--- a/bundles/org.eclipse.swt.cocoa.macosx.aarch64/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.swt.cocoa.macosx.aarch64/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Fragment-Host: org.eclipse.swt;bundle-version="[3.116.0,4.0.0)"
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.cocoa.macosx.aarch64; singleton:=true
-Bundle-Version: 3.120.100.qualifier
+Bundle-Version: 3.121.0.qualifier
 Bundle-ManifestVersion: 2
 Bundle-Localization: fragment
 Export-Package: 

--- a/bundles/org.eclipse.swt.cocoa.macosx.aarch64/pom.xml
+++ b/bundles/org.eclipse.swt.cocoa.macosx.aarch64/pom.xml
@@ -21,7 +21,7 @@
   </parent>
   <groupId>org.eclipse.swt</groupId>
   <artifactId>org.eclipse.swt.cocoa.macosx.aarch64</artifactId>
-  <version>3.120.100-SNAPSHOT</version>
+  <version>3.121.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   
   <properties>

--- a/bundles/org.eclipse.swt.cocoa.macosx.x86_64/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.swt.cocoa.macosx.x86_64/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Fragment-Host: org.eclipse.swt;bundle-version="[3.116.0,4.0.0)"
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.cocoa.macosx.x86_64; singleton:=true
-Bundle-Version: 3.120.100.qualifier
+Bundle-Version: 3.121.0.qualifier
 Bundle-ManifestVersion: 2
 Bundle-Localization: fragment
 Export-Package: 

--- a/bundles/org.eclipse.swt.cocoa.macosx.x86_64/pom.xml
+++ b/bundles/org.eclipse.swt.cocoa.macosx.x86_64/pom.xml
@@ -21,7 +21,7 @@
   </parent>
   <groupId>org.eclipse.swt</groupId>
   <artifactId>org.eclipse.swt.cocoa.macosx.x86_64</artifactId>
-  <version>3.120.100-SNAPSHOT</version>
+  <version>3.121.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   
   <properties>

--- a/bundles/org.eclipse.swt.gtk.linux.aarch64/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.swt.gtk.linux.aarch64/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Fragment-Host: org.eclipse.swt;bundle-version="[3.116.0,4.0.0)"
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.gtk.linux.aarch64; singleton:=true
-Bundle-Version: 3.120.100.qualifier
+Bundle-Version: 3.121.0.qualifier
 Bundle-ManifestVersion: 2
 Bundle-Localization: fragment
 Export-Package: 

--- a/bundles/org.eclipse.swt.gtk.linux.aarch64/pom.xml
+++ b/bundles/org.eclipse.swt.gtk.linux.aarch64/pom.xml
@@ -21,7 +21,7 @@
   </parent>
   <groupId>org.eclipse.swt</groupId>
   <artifactId>org.eclipse.swt.gtk.linux.aarch64</artifactId>
-  <version>3.120.100-SNAPSHOT</version>
+  <version>3.121.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <properties>

--- a/bundles/org.eclipse.swt.gtk.linux.loongarch64/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.swt.gtk.linux.loongarch64/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Fragment-Host: org.eclipse.swt;bundle-version="[3.116.0,4.0.0)"
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.gtk.linux.loongarch64; singleton:=true
-Bundle-Version: 3.120.100.qualifier
+Bundle-Version: 3.121.0.qualifier
 Bundle-ManifestVersion: 2
 Bundle-Localization: fragment
 Export-Package: 

--- a/bundles/org.eclipse.swt.gtk.linux.loongarch64/pom.xml
+++ b/bundles/org.eclipse.swt.gtk.linux.loongarch64/pom.xml
@@ -16,12 +16,12 @@
   <parent>
     <artifactId>binaries-parent</artifactId>
     <groupId>eclipse.platform.swt.binaries</groupId>
-    <version>4.23.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../binaries-parent/</relativePath>
   </parent>
   <groupId>org.eclipse.swt</groupId>
   <artifactId>org.eclipse.swt.gtk.linux.loongarch64</artifactId>
-  <version>3.120.100-SNAPSHOT</version>
+  <version>3.121.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <properties>

--- a/bundles/org.eclipse.swt.gtk.linux.ppc64le/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.swt.gtk.linux.ppc64le/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Fragment-Host: org.eclipse.swt;bundle-version="[3.116.0,4.0.0)"
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.gtk.linux.ppc64le;singleton:=true
-Bundle-Version: 3.120.100.qualifier
+Bundle-Version: 3.121.0.qualifier
 Bundle-ManifestVersion: 2
 Bundle-Localization: fragment
 Export-Package: 

--- a/bundles/org.eclipse.swt.gtk.linux.ppc64le/pom.xml
+++ b/bundles/org.eclipse.swt.gtk.linux.ppc64le/pom.xml
@@ -21,7 +21,7 @@
   </parent>
   <groupId>org.eclipse.swt</groupId>
   <artifactId>org.eclipse.swt.gtk.linux.ppc64le</artifactId>
-  <version>3.120.100-SNAPSHOT</version>
+  <version>3.121.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <properties>

--- a/bundles/org.eclipse.swt.gtk.linux.x86_64/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.swt.gtk.linux.x86_64/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Fragment-Host: org.eclipse.swt;bundle-version="[3.116.0,4.0.0)"
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.gtk.linux.x86_64; singleton:=true
-Bundle-Version: 3.120.100.qualifier
+Bundle-Version: 3.121.0.qualifier
 Bundle-ManifestVersion: 2
 Bundle-Localization: fragment
 Export-Package: 

--- a/bundles/org.eclipse.swt.gtk.linux.x86_64/pom.xml
+++ b/bundles/org.eclipse.swt.gtk.linux.x86_64/pom.xml
@@ -21,7 +21,7 @@
   </parent>
   <groupId>org.eclipse.swt</groupId>
   <artifactId>org.eclipse.swt.gtk.linux.x86_64</artifactId>
-  <version>3.120.100-SNAPSHOT</version>
+  <version>3.121.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <properties>

--- a/bundles/org.eclipse.swt.gtk.win32.x86_64/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.swt.gtk.win32.x86_64/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Fragment-Host: org.eclipse.swt;bundle-version="[3.116.0,4.0.0)"
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.gtk.win32.x86_64; singleton:=true
-Bundle-Version: 3.120.100.qualifier
+Bundle-Version: 3.121.0.qualifier
 Bundle-ManifestVersion: 2
 Bundle-Localization: fragment
 Export-Package: 

--- a/bundles/org.eclipse.swt.gtk.win32.x86_64/pom.xml
+++ b/bundles/org.eclipse.swt.gtk.win32.x86_64/pom.xml
@@ -17,12 +17,12 @@
   <parent>
     <artifactId>binaries-parent</artifactId>
     <groupId>eclipse.platform.swt.binaries</groupId>
-    <version>4.10.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../binaries-parent/</relativePath>
   </parent>
   <groupId>org.eclipse.swt</groupId>
   <artifactId>org.eclipse.swt.gtk.win32.x86_64</artifactId>
-  <version>3.120.100-SNAPSHOT</version>
+  <version>3.121.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <properties>

--- a/bundles/org.eclipse.swt.win32.win32.x86_64/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.swt.win32.win32.x86_64/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Fragment-Host: org.eclipse.swt;bundle-version="[3.116.0,4.0.0)"
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.win32.win32.x86_64; singleton:=true
-Bundle-Version: 3.120.100.qualifier
+Bundle-Version: 3.121.0.qualifier
 Bundle-ManifestVersion: 2
 Bundle-Localization: fragment
 Export-Package: 

--- a/bundles/org.eclipse.swt.win32.win32.x86_64/pom.xml
+++ b/bundles/org.eclipse.swt.win32.win32.x86_64/pom.xml
@@ -21,7 +21,7 @@
   </parent>
   <groupId>org.eclipse.swt</groupId>
   <artifactId>org.eclipse.swt.win32.win32.x86_64</artifactId>
-  <version>3.120.100-SNAPSHOT</version>
+  <version>3.121.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <properties>


### PR DESCRIPTION
Fixes build issue caused by
https://github.com/eclipse-platform/eclipse.platform.swt/issues/55