### PR TITLE
Align 'version.suffix' property with 4.27-stream version of o.e.swt

### DIFF
--- a/bundles/binaries-parent/build.xml
+++ b/bundles/binaries-parent/build.xml
@@ -6,7 +6,7 @@
 	<property name="swt.arch" value="${arch}" />
 	
 	<!-- These properties are used by eclipse when exporting as Deployable plugin and fragments -->
-	<property name="version.suffix" value="3.121.100" />
+	<property name="version.suffix" value="3.122.100" />
 	
 	<condition property="plugindir" value="../../../eclipse.platform.swt/bundles/org.eclipse.swt" else="${buildDirectory}/plugins/org.eclipse.swt">
 		<available file="../../../eclipse.platform.swt/bundles/org.eclipse.swt" type="dir"/>


### PR DESCRIPTION
I wonder why this did not cause any trouble.
Maybe the version is not actually really needed?