### PR TITLE
[Build] Unify 'natives' ant-script invocation into the binaries-parent

### DIFF
--- a/bundles/binaries-parent/pom.xml
+++ b/bundles/binaries-parent/pom.xml
@@ -28,8 +28,8 @@
             forceContextQualifier gets updated during build input process using
             ant script <SWT source repo>/bundles/org.eclipse.swt/buildInternal.xml 
         -->
-        
         <forceContextQualifier>v20221207-0524</forceContextQualifier>
+        <buildid>${buildId}</buildid>
     </properties>
 
     <build>
@@ -66,28 +66,47 @@
                     <execution>
                         <id>normal</id>
                         <phase>initialize</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
                         <configuration>
                             <target>
                                 <property name="copy.src.dir" value="src" />
                                 <ant antfile="../binaries-parent/build.xml" target="copy.${ws}.src" />
                             </target>
                         </configuration>
+                    </execution>
+                    <execution>
+                        <id>natives</id>
+                        <phase>process-resources</phase>
                         <goals>
                             <goal>run</goal>
                         </goals>
+                        <configuration>
+                            <target>
+                                <!-- See https://stackoverflow.com/a/53227117 and http://ant-contrib.sourceforge.net/tasks/tasks/index.html -->
+                                <taskdef resource="net/sf/antcontrib/antlib.xml" />
+                                <if>
+                                    <equals arg1="${native}" arg2="${ws}.${os}.${arch}" />
+                                    <then>
+                                        <ant antfile="../binaries-parent/build.xml" target="build_libraries" />
+                                    </then>
+                                </if>
+                            </target>
+                        </configuration>
                     </execution>
                     <execution>
                         <id>swtdownload</id>
                         <phase>package</phase>
-                        <configuration>
-                            <target>
-                                <property name="eclipse.version" value="${releaseNumberSDK}" />
-                                <ant antfile="../binaries-parent/build.xml" target="swtdownload"/>
-                            </target>
-                        </configuration>
                         <goals>
                             <goal>run</goal>
                         </goals>
+                        <configuration>
+                            <target>
+                                <property name="eclipse.version" value="${releaseNumberSDK}" />
+                                <ant antfile="../binaries-parent/build.xml" target="swtdownload" />
+                            </target>
+                        </configuration>
                     </execution>
                 </executions>
                 <dependencies>
@@ -105,6 +124,17 @@
                         <groupId>org.apache.ant</groupId>
                         <artifactId>ant-apache-bsf</artifactId>
                         <version>1.10.12</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>ant-contrib</groupId>
+                        <artifactId>ant-contrib</artifactId>
+                        <version>1.0b3</version>
+                        <exclusions>
+                            <exclusion>
+                                <groupId>ant</groupId>
+                                <artifactId>ant</artifactId>
+                            </exclusion>
+                        </exclusions>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/bundles/org.eclipse.swt.cocoa.macosx.aarch64/pom.xml
+++ b/bundles/org.eclipse.swt.cocoa.macosx.aarch64/pom.xml
@@ -28,42 +28,7 @@
     <os>macosx</os>
     <ws>cocoa</ws>
     <arch>aarch64</arch>
-    <buildid>${buildId}</buildid>
     <targets></targets>
   </properties>
 
-  <!-- This has to be here. Profiles are not inheritable. -->
-  <profiles>
-    <profile>
-      <id>build-natives</id>
-      <activation>
-        <property>
-          <!-- This has to be hardcoded. Profiles are not allowed to use pom defined properties :-( -->
-          <name>native</name>
-          <value>cocoa.macosx.aarch64</value>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-antrun-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>natives</id>
-                <phase>process-resources</phase>
-                <configuration>
-                  <target>
-                    <ant antfile="../binaries-parent/build.xml" target="build_libraries"/>
-                  </target>
-                </configuration>
-                <goals>
-                  <goal>run</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 </project>

--- a/bundles/org.eclipse.swt.cocoa.macosx.x86_64/pom.xml
+++ b/bundles/org.eclipse.swt.cocoa.macosx.x86_64/pom.xml
@@ -28,42 +28,7 @@
     <os>macosx</os>
     <ws>cocoa</ws>
     <arch>x86_64</arch>
-    <buildid>${buildId}</buildid>
     <targets></targets>
   </properties>
 
-  <!-- This has to be here. Profiles are not inheritable. -->
-  <profiles>
-    <profile>
-      <id>build-natives</id>
-      <activation>
-        <property>
-          <!-- This has to be hardcoded. Profiles are not allowed to use pom defined properties :-( -->
-          <name>native</name>
-          <value>cocoa.macosx.x86_64</value>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-antrun-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>natives</id>
-                <phase>process-resources</phase>
-                <configuration>
-                  <target>
-                    <ant antfile="../binaries-parent/build.xml" target="build_libraries"/>
-                  </target>
-                </configuration>
-                <goals>
-                  <goal>run</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 </project>

--- a/bundles/org.eclipse.swt.gtk.linux.aarch64/pom.xml
+++ b/bundles/org.eclipse.swt.gtk.linux.aarch64/pom.xml
@@ -28,42 +28,7 @@
     <os>linux</os>
     <ws>gtk</ws>
     <arch>aarch64</arch>
-    <buildid>${buildId}</buildid>
     <targets>install</targets>
   </properties>
 
-  <!-- This has to be here. Profiles are not inheritable. -->
-  <profiles>
-    <profile>
-      <id>build-natives</id>
-      <activation>
-        <property>
-          <!-- This has to be hardcoded. Profiles are not allowed to use pom defined properties :-( -->
-          <name>native</name>
-          <value>gtk.linux.aarch64</value>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-antrun-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>natives</id>
-                <phase>process-resources</phase>
-                <configuration>
-                  <target>
-                    <ant antfile="../binaries-parent/build.xml" target="build_libraries"/>
-                  </target>
-                </configuration>
-                <goals>
-                  <goal>run</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 </project>

--- a/bundles/org.eclipse.swt.gtk.linux.loongarch64/pom.xml
+++ b/bundles/org.eclipse.swt.gtk.linux.loongarch64/pom.xml
@@ -28,42 +28,7 @@
     <os>linux</os>
     <ws>gtk</ws>
     <arch>loongarch64</arch>
-    <buildid>${buildId}</buildid>
     <targets>install</targets>
   </properties>
 
-  <!-- This has to be here. Profiles are not inheritable. -->
-  <profiles>
-    <profile>
-      <id>build-natives</id>
-      <activation>
-        <property>
-          <!-- This has to be hardcoded. Profiles are not allowed to use pom defined properties :-( -->
-          <name>native</name>
-          <value>gtk.linux.loongarch64</value>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-antrun-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>natives</id>
-                <phase>process-resources</phase>
-                <configuration>
-                  <target>
-                    <ant antfile="../binaries-parent/build.xml" target="build_libraries"/>
-                  </target>
-                </configuration>
-                <goals>
-                  <goal>run</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 </project>

--- a/bundles/org.eclipse.swt.gtk.linux.ppc64le/pom.xml
+++ b/bundles/org.eclipse.swt.gtk.linux.ppc64le/pom.xml
@@ -28,42 +28,7 @@
     <os>linux</os>
     <ws>gtk</ws>
     <arch>ppc64le</arch>
-    <buildid>${buildId}</buildid>
     <targets>install</targets>
   </properties>
 
-  <!-- This has to be here. Profiles are not inheritable. -->
-  <profiles>
-    <profile>
-      <id>build-natives</id>
-      <activation>
-        <property>
-          <!-- This has to be hardcoded. Profiles are not allowed to use pom defined properties :-( -->
-          <name>native</name>
-          <value>gtk.linux.ppc64le</value>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-antrun-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>natives</id>
-                <phase>process-resources</phase>
-                <configuration>
-                  <target>
-                    <ant antfile="../binaries-parent/build.xml" target="build_libraries"/>
-                  </target>
-                </configuration>
-                <goals>
-                  <goal>run</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 </project>

--- a/bundles/org.eclipse.swt.gtk.linux.x86_64/pom.xml
+++ b/bundles/org.eclipse.swt.gtk.linux.x86_64/pom.xml
@@ -28,42 +28,7 @@
     <os>linux</os>
     <ws>gtk</ws>
     <arch>x86_64</arch>
-    <buildid>${buildId}</buildid>
     <targets>install</targets>
   </properties>
 
-  <!-- This has to be here. Profiles are not inheritable. -->
-  <profiles>
-    <profile>
-      <id>build-natives</id>
-      <activation>
-        <property>
-          <!-- This has to be hardcoded. Profiles are not allowed to use pom defined properties :-( -->
-          <name>native</name>
-          <value>gtk.linux.x86_64</value>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-antrun-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>natives</id>
-                <phase>process-resources</phase>
-                <configuration>
-                  <target>
-                    <ant antfile="../binaries-parent/build.xml" target="build_libraries"/>
-                  </target>
-                </configuration>
-                <goals>
-                  <goal>run</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 </project>

--- a/bundles/org.eclipse.swt.win32.win32.x86_64/pom.xml
+++ b/bundles/org.eclipse.swt.win32.win32.x86_64/pom.xml
@@ -28,42 +28,7 @@
     <os>win32</os>
     <ws>win32</ws>
     <arch>x86_64</arch>
-    <buildid>${buildId}</buildid>
     <targets>x86_64 all install</targets>
   </properties>
 
-  <!-- This has to be here. Profiles are not inheritable. -->
-  <profiles>
-    <profile>
-      <id>build-natives</id>
-      <activation>
-        <property>
-          <!-- This has to be hardcoded. Profiles are not allowed to use pom defined properties :-( -->
-          <name>native</name>
-          <value>win32.win32.x86_64</value>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-antrun-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>natives</id>
-                <phase>process-resources</phase>
-                <configuration>
-                  <target>
-                    <ant antfile="../binaries-parent/build.xml" target="build_libraries"/>
-                  </target>
-                </configuration>
-                <goals>
-                  <goal>run</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 </project>


### PR DESCRIPTION
Use the ant-contrib 'if' task to check if execution of the natives build is requested. This saves many duplicated profiles in each platform-specific fragment.