### PR TITLE
[Build] Skip default checkout, improve readability and only use tabs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,15 +1,16 @@
 pipeline {
 	options {
+		skipDefaultCheckout() // Specialiced checkout is performed below
+		timestamps()
 		timeout(time: 90, unit: 'MINUTES')
 		buildDiscarder(logRotator(numToKeepStr:'5'))
 		disableConcurrentBuilds(abortPrevious: true)
-		timestamps()
 	}
-  agent {
-    kubernetes {
-      label 'swtbuild-pod'
-      defaultContainer 'container'
-      yaml """
+	agent {
+		kubernetes {
+			label 'swtbuild-pod'
+			defaultContainer 'container'
+			yaml """
 apiVersion: v1
 kind: Pod
 spec:
@@ -21,7 +22,7 @@ spec:
         cpu: "100m"
       limits:
         memory: "512Mi"
-        cpu: "500m"  
+        cpu: "500m"
   - name: container
     image: akurtakov/swtbuild@sha256:2cd3dfdea1f250597c9e3797512953c03e2182344e86976c1b60117c5dd36a9e
     tty: true
@@ -75,17 +76,19 @@ spec:
     persistentVolumeClaim:
       claimName: tools-claim-jiro-platform
 """
-    }
-  }
-  environment {
-        MAVEN_OPTS = "-Xmx4G"
-  }
+		}
+	}
+	environment {
+		MAVEN_OPTS = "-Xmx4G"
+	}
 	stages {
-		stage('Prepare-environment') {
+		stage('Prepare environment') {
 			steps {
 				container('container') {
 					dir ('eclipse.platform.swt') {
-						checkout([$class: 'GitSCM', branches: [[name: '*/master']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'CloneOption', timeout: 120]], submoduleCfg: [], userRemoteConfigs: [[url: 'https://github.com/eclipse-platform/eclipse.platform.swt.git']]])
+						checkout([$class: 'GitSCM', branches: [[name: '*/master']], 
+							extensions: [[$class: 'CloneOption', timeout: 120]], userRemoteConfigs: [[url: 'https://github.com/eclipse-platform/eclipse.platform.swt.git']]
+						])
 					}
 					dir ('eclipse.platform.swt.binaries') {
 						checkout scm
@@ -97,17 +100,24 @@ spec:
 			steps {
 				container('container') {
 					wrap([$class: 'Xvnc', useXauthority: true]) {
-					    withEnv(["JAVA_HOME=${ tool 'openjdk-jdk17-latest' }"]) {
-					        dir ('eclipse.platform.swt.binaries') {
-					    	    sh '/opt/tools/apache-maven/latest/bin/mvn --batch-mode -Pbuild-individual-bundles -DforceContextQualifier=zzz -Dnative=gtk.linux.x86_64 -Dcompare-version-with-baselines.skip=true -Dmaven.compiler.failOnWarning=true install '
-					        }
-					        dir ('eclipse.platform.swt') {
-					    	    sh '/opt/tools/apache-maven/latest/bin/mvn --batch-mode -Pbuild-individual-bundles -DcheckAllWS=true -DforkCount=0 -Dcompare-version-with-baselines.skip=false -Dmaven.compiler.failOnWarning=true \
-						    	    -Dmaven.test.failure.ignore=true -Dmaven.test.error.ignore=true \
-						    	    clean verify '
-					        }
-					    }
-				    }
+						withEnv(["JAVA_HOME=${ tool 'openjdk-jdk17-latest' }"]) {
+							dir ('eclipse.platform.swt.binaries') {
+								sh '''
+									/opt/tools/apache-maven/latest/bin/mvn install \
+										--batch-mode -Pbuild-individual-bundles -DforceContextQualifier=zzz -Dnative=gtk.linux.x86_64 \
+										-Dcompare-version-with-baselines.skip=true -Dmaven.compiler.failOnWarning=true
+								'''
+							}
+							dir ('eclipse.platform.swt') {
+								sh '''
+									/opt/tools/apache-maven/latest/bin/mvn clean verify \
+										--batch-mode -Pbuild-individual-bundles -DcheckAllWS=true -DforkCount=0 \
+										-Dcompare-version-with-baselines.skip=false -Dmaven.compiler.failOnWarning=true \
+										-Dmaven.test.failure.ignore=true -Dmaven.test.error.ignore=true
+								'''
+							}
+						}
+					}
 				}
 			}
 			post {


### PR DESCRIPTION
Skip the unnecessary default check-out, because the build operates only on the later site-by-site checked-out sources of o.e.swt and o.e.swt.binaries. Skipping the default checkout can save about two to three minutes for each verification build.

Only use tabs for indentation except for the yml section, where tabs are not supported.
And format lines to make them shorter.