### PR TITLE
Switch SWT to Java 17 runtime

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
         <groupId>org.eclipse.tycho</groupId>
         <artifactId>target-platform-configuration</artifactId>
         <configuration>
-          <executionEnvironment>JavaSE-11</executionEnvironment>
+          <executionEnvironment>JavaSE-17</executionEnvironment>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
Note: there are still build files requiring Java 11 for execution (Jenkinsfile and buildSWT.xml).

See https://github.com/eclipse-platform/eclipse.platform.swt/issues/626

Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/625