### PR TITLE
Version bump for binaries

### DIFF
--- a/bundles/org.eclipse.swt.cocoa.macosx.aarch64/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.swt.cocoa.macosx.aarch64/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Fragment-Host: org.eclipse.swt;bundle-version="[3.116.0,4.0.0)"
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.cocoa.macosx.aarch64; singleton:=true
-Bundle-Version: 3.119.100.qualifier
+Bundle-Version: 3.119.200.qualifier
 Bundle-ManifestVersion: 2
 Bundle-Localization: fragment
 Export-Package: 

--- a/bundles/org.eclipse.swt.cocoa.macosx.aarch64/build.xml
+++ b/bundles/org.eclipse.swt.cocoa.macosx.aarch64/build.xml
@@ -6,7 +6,7 @@
 	<property name="swt.arch" value="aarch64" />
 	
 	<!-- These properties are used by eclipse when exporting as Deployable plugin and fragments -->
-	<property name="version.suffix" value="3.119.100" />
+	<property name="version.suffix" value="3.119.200" />
 	
 	<condition property="plugindir" value="../../../eclipse.platform.swt/bundles/org.eclipse.swt" else="${buildDirectory}/plugins/org.eclipse.swt">
 		<available file="../../../eclipse.platform.swt/bundles/org.eclipse.swt" type="dir"/>

--- a/bundles/org.eclipse.swt.cocoa.macosx.aarch64/pom.xml
+++ b/bundles/org.eclipse.swt.cocoa.macosx.aarch64/pom.xml
@@ -21,7 +21,7 @@
   </parent>
   <groupId>org.eclipse.swt</groupId>
   <artifactId>org.eclipse.swt.cocoa.macosx.aarch64</artifactId>
-  <version>3.119.100-SNAPSHOT</version>
+  <version>3.119.200-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   
   <properties>

--- a/bundles/org.eclipse.swt.cocoa.macosx.x86_64/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.swt.cocoa.macosx.x86_64/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Fragment-Host: org.eclipse.swt;bundle-version="[3.116.0,4.0.0)"
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.cocoa.macosx.x86_64; singleton:=true
-Bundle-Version: 3.119.100.qualifier
+Bundle-Version: 3.119.200.qualifier
 Bundle-ManifestVersion: 2
 Bundle-Localization: fragment
 Export-Package: 

--- a/bundles/org.eclipse.swt.cocoa.macosx.x86_64/build.xml
+++ b/bundles/org.eclipse.swt.cocoa.macosx.x86_64/build.xml
@@ -6,7 +6,7 @@
 	<property name="swt.arch" value="x86_64" />
 	
 	<!-- These properties are used by eclipse when exporting as Deployable plugin and fragments -->
-	<property name="version.suffix" value="3.119.100" />
+	<property name="version.suffix" value="3.119.200" />
 	
 	<condition property="plugindir" value="../../../eclipse.platform.swt/bundles/org.eclipse.swt" else="${buildDirectory}/plugins/org.eclipse.swt">
 		<available file="../../../eclipse.platform.swt/bundles/org.eclipse.swt" type="dir"/>

--- a/bundles/org.eclipse.swt.cocoa.macosx.x86_64/pom.xml
+++ b/bundles/org.eclipse.swt.cocoa.macosx.x86_64/pom.xml
@@ -21,7 +21,7 @@
   </parent>
   <groupId>org.eclipse.swt</groupId>
   <artifactId>org.eclipse.swt.cocoa.macosx.x86_64</artifactId>
-  <version>3.119.100-SNAPSHOT</version>
+  <version>3.119.200-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   
   <properties>

--- a/bundles/org.eclipse.swt.gtk.linux.aarch64/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.swt.gtk.linux.aarch64/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Fragment-Host: org.eclipse.swt;bundle-version="[3.116.0,4.0.0)"
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.gtk.linux.aarch64; singleton:=true
-Bundle-Version: 3.119.100.qualifier
+Bundle-Version: 3.119.200.qualifier
 Bundle-ManifestVersion: 2
 Bundle-Localization: fragment
 Export-Package: 

--- a/bundles/org.eclipse.swt.gtk.linux.aarch64/build.xml
+++ b/bundles/org.eclipse.swt.gtk.linux.aarch64/build.xml
@@ -7,7 +7,7 @@
 	<property name="targets" value="install"/>
 	
 	<!-- These properties are used by eclipse when exporting as Deployable plugin and fragments -->
-	<property name="version.suffix" value="3.119.100" />
+	<property name="version.suffix" value="3.119.200" />
 
 	<condition property="plugindir" value="../../../eclipse.platform.swt/bundles/org.eclipse.swt" else="${buildDirectory}/plugins/org.eclipse.swt">
 		<available file="../../../eclipse.platform.swt/bundles/org.eclipse.swt" type="dir"/>

--- a/bundles/org.eclipse.swt.gtk.linux.aarch64/pom.xml
+++ b/bundles/org.eclipse.swt.gtk.linux.aarch64/pom.xml
@@ -21,7 +21,7 @@
   </parent>
   <groupId>org.eclipse.swt</groupId>
   <artifactId>org.eclipse.swt.gtk.linux.aarch64</artifactId>
-  <version>3.119.100-SNAPSHOT</version>
+  <version>3.119.200-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <properties>

--- a/bundles/org.eclipse.swt.gtk.linux.ppc64le/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.swt.gtk.linux.ppc64le/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Fragment-Host: org.eclipse.swt;bundle-version="[3.116.0,4.0.0)"
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.gtk.linux.ppc64le;singleton:=true
-Bundle-Version: 3.119.100.qualifier
+Bundle-Version: 3.119.200.qualifier
 Bundle-ManifestVersion: 2
 Bundle-Localization: fragment
 Export-Package: 

--- a/bundles/org.eclipse.swt.gtk.linux.ppc64le/build.xml
+++ b/bundles/org.eclipse.swt.gtk.linux.ppc64le/build.xml
@@ -7,7 +7,7 @@
 	<property name="targets" value="install"/>
 	
 	<!-- These properties are used by eclipse when exporting as Deployable plugin and fragments -->
-	<property name="version.suffix" value="3.119.100" />
+	<property name="version.suffix" value="3.119.200" />
 	
 	<condition property="plugindir" value="../../../eclipse.platform.swt/bundles/org.eclipse.swt" else="${buildDirectory}/plugins/org.eclipse.swt">
 		<available file="../../../eclipse.platform.swt/bundles/org.eclipse.swt" type="dir"/>

--- a/bundles/org.eclipse.swt.gtk.linux.ppc64le/pom.xml
+++ b/bundles/org.eclipse.swt.gtk.linux.ppc64le/pom.xml
@@ -21,7 +21,7 @@
   </parent>
   <groupId>org.eclipse.swt</groupId>
   <artifactId>org.eclipse.swt.gtk.linux.ppc64le</artifactId>
-  <version>3.119.100-SNAPSHOT</version>
+  <version>3.119.200-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <properties>

--- a/bundles/org.eclipse.swt.gtk.linux.x86_64/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.swt.gtk.linux.x86_64/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Fragment-Host: org.eclipse.swt;bundle-version="[3.116.0,4.0.0)"
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.gtk.linux.x86_64; singleton:=true
-Bundle-Version: 3.119.100.qualifier
+Bundle-Version: 3.119.200.qualifier
 Bundle-ManifestVersion: 2
 Bundle-Localization: fragment
 Export-Package: 

--- a/bundles/org.eclipse.swt.gtk.linux.x86_64/build.xml
+++ b/bundles/org.eclipse.swt.gtk.linux.x86_64/build.xml
@@ -7,7 +7,7 @@
 	<property name="targets" value="install"/>
 	
 	<!-- These properties are used by eclipse when exporting as Deployable plugin and fragments -->
-	<property name="version.suffix" value="3.119.100" />
+	<property name="version.suffix" value="3.119.200" />
 
 	<condition property="plugindir" value="../../../eclipse.platform.swt/bundles/org.eclipse.swt" else="${buildDirectory}/plugins/org.eclipse.swt">
 		<available file="../../../eclipse.platform.swt/bundles/org.eclipse.swt" type="dir"/>

--- a/bundles/org.eclipse.swt.gtk.linux.x86_64/pom.xml
+++ b/bundles/org.eclipse.swt.gtk.linux.x86_64/pom.xml
@@ -21,7 +21,7 @@
   </parent>
   <groupId>org.eclipse.swt</groupId>
   <artifactId>org.eclipse.swt.gtk.linux.x86_64</artifactId>
-  <version>3.119.100-SNAPSHOT</version>
+  <version>3.119.200-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <properties>

--- a/bundles/org.eclipse.swt.win32.win32.x86_64/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.swt.win32.win32.x86_64/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Fragment-Host: org.eclipse.swt;bundle-version="[3.116.0,4.0.0)"
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.win32.win32.x86_64; singleton:=true
-Bundle-Version: 3.119.100.qualifier
+Bundle-Version: 3.119.200.qualifier
 Bundle-ManifestVersion: 2
 Bundle-Localization: fragment
 Export-Package: 

--- a/bundles/org.eclipse.swt.win32.win32.x86_64/build.xml
+++ b/bundles/org.eclipse.swt.win32.win32.x86_64/build.xml
@@ -7,7 +7,7 @@
 	<property name="targets" value="x86_64 all install"/>
 	
 	<!-- These properties are used by eclipse when exporting as Deployable plugin and fragments -->
-	<property name="version.suffix" value="3.119.100" />
+	<property name="version.suffix" value="3.119.200" />
 	
 	<condition property="plugindir" value="../../../eclipse.platform.swt/bundles/org.eclipse.swt" else="${buildDirectory}/plugins/org.eclipse.swt">
 		<available file="../../../eclipse.platform.swt/bundles/org.eclipse.swt" type="dir"/>

--- a/bundles/org.eclipse.swt.win32.win32.x86_64/pom.xml
+++ b/bundles/org.eclipse.swt.win32.win32.x86_64/pom.xml
@@ -21,7 +21,7 @@
   </parent>
   <groupId>org.eclipse.swt</groupId>
   <artifactId>org.eclipse.swt.win32.win32.x86_64</artifactId>
-  <version>3.119.100-SNAPSHOT</version>
+  <version>3.119.200-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <properties>


### PR DESCRIPTION
Version bump for binaries:   backportBug 579335: Fix crash on long styled lines on Windows #823

fixes : #823 in eclipse.platform.swt

cc/ @lshanmug 