### PR TITLE
changes in pom file 

### DIFF
--- a/bundles/binaries-parent/pom.xml
+++ b/bundles/binaries-parent/pom.xml
@@ -30,7 +30,7 @@
             ant script <SWT source repo>/bundles/org.eclipse.swt/buildInternal.xml 
         -->
         
-        <forceContextQualifier>v20220907-1543</forceContextQualifier>
+        <forceContextQualifier>v20231010-1245</forceContextQualifier>
     </properties>
 
     <build>


### PR DESCRIPTION
fixes: changes in pom file required in binaries-parent
For issue: backport Bug 579335: Fix crash on long styled lines on Windows #823 in eclipse.platform.swt

cc/ @sravanlakkimsetti 