### PR TITLE
Remove unncessary src.excludes

### DIFF
--- a/bundles/org.eclipse.swt.cocoa.macosx.aarch64/build.properties
+++ b/bundles/org.eclipse.swt.cocoa.macosx.aarch64/build.properties
@@ -14,4 +14,3 @@ bin.includes = .,*.jnilib,about_files/,about.html,fragment.properties
 bin.excludes = library/
 source.. = src/
 src.includes = about.html,about_files/
-src.excludes = external.xpt

--- a/bundles/org.eclipse.swt.cocoa.macosx.x86_64/build.properties
+++ b/bundles/org.eclipse.swt.cocoa.macosx.x86_64/build.properties
@@ -14,4 +14,3 @@ bin.includes = .,*.jnilib,about_files/,about.html,fragment.properties
 bin.excludes = library/
 source.. = src/
 src.includes = about.html,about_files/
-src.excludes = external.xpt

--- a/bundles/org.eclipse.swt.gtk.linux.aarch64/build.properties
+++ b/bundles/org.eclipse.swt.gtk.linux.aarch64/build.properties
@@ -13,4 +13,3 @@ bin.includes = .,*.so,about_files/,about.html,fragment.properties
 bin.excludes = library/
 source.. = src/
 src.includes = about.html,about_files/
-src.excludes = external.xpt

--- a/bundles/org.eclipse.swt.gtk.linux.loongarch64/build.properties
+++ b/bundles/org.eclipse.swt.gtk.linux.loongarch64/build.properties
@@ -13,4 +13,3 @@ bin.includes = .,*.so,about_files/,about.html,fragment.properties
 bin.excludes = library/
 source.. = src/
 src.includes = about.html,about_files/
-src.excludes = external.xpt

--- a/bundles/org.eclipse.swt.gtk.linux.ppc64le/build.properties
+++ b/bundles/org.eclipse.swt.gtk.linux.ppc64le/build.properties
@@ -13,4 +13,3 @@ bin.includes = .,*.so,about_files/,about.html,fragment.properties
 bin.excludes = library/
 source.. = src/
 src.includes = about.html,about_files/
-src.excludes = external.xpt

--- a/bundles/org.eclipse.swt.gtk.linux.x86_64/build.properties
+++ b/bundles/org.eclipse.swt.gtk.linux.x86_64/build.properties
@@ -14,4 +14,3 @@ bin.includes = .,*.so,about_files/,about.html,fragment.properties
 bin.excludes = library/
 source.. = src/
 src.includes = about.html,about_files/
-src.excludes = external.xpt

--- a/bundles/org.eclipse.swt.win32.win32.x86_64/build.properties
+++ b/bundles/org.eclipse.swt.win32.win32.x86_64/build.properties
@@ -14,4 +14,3 @@ bin.includes = .,*.dll,about_files/,about.html,fragment.properties
 bin.excludes = library/
 source.. = src/
 src.includes = about.html,about_files/
-src.excludes = external.xpt


### PR DESCRIPTION
I have not found a single hit for xpt in the `swt(.binaries)` repos.
@akurtakov, @iloveeclipse can you tell what `external.xpt` was supposed to be?