### PR TITLE
set UTF-8 encoding

### DIFF
--- a/bundles/org.eclipse.swt.win32.win32.x86_64/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.eclipse.swt.win32.win32.x86_64/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8


### PR DESCRIPTION
to reduce workspace warnings