### PR TITLE
Touch bundles affected by the changed ecj version

### DIFF
--- a/bundles/org.eclipse.swt.cocoa.macosx.aarch64/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.swt.cocoa.macosx.aarch64/forceQualifierUpdate.txt
@@ -1,2 +1,3 @@
 # To force a version qualifier update add the bug here
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.swt.cocoa.macosx.x86_64/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.swt.cocoa.macosx.x86_64/forceQualifierUpdate.txt
@@ -2,3 +2,4 @@
 Bug 434039 - SWT fragment source is not always included in SDK or repository
 Bug 436000 - Comparator errors in I20140527-2000 build
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.swt.gtk.linux.aarch64/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.swt.gtk.linux.aarch64/forceQualifierUpdate.txt
@@ -1,3 +1,4 @@
 # To force a version qualifier update add the bug here
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1608
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.swt.gtk.linux.ppc64le/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.swt.gtk.linux.ppc64le/forceQualifierUpdate.txt
@@ -2,3 +2,4 @@
 Bug 434039 - SWT fragment source is not always included in SDK or repository
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1608
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.swt.gtk.linux.x86_64/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.swt.gtk.linux.x86_64/forceQualifierUpdate.txt
@@ -2,3 +2,4 @@
 Bug 434039 - SWT fragment source is not always included in SDK or repository
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1608
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.swt.win32.win32.x86_64/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.swt.win32.win32.x86_64/forceQualifierUpdate.txt
@@ -2,3 +2,4 @@
 Bug 434039 - SWT fragment source is not always included in SDK or repository
 Bug 436000 - Comparator errors in I20140527-2000 build
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659


### PR DESCRIPTION
See https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1394 
See https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659