### PR TITLE
Touch fragments after CTabFolderRenderer change in SWT

### DIFF
--- a/bundles/org.eclipse.swt.cocoa.macosx.aarch64/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.swt.cocoa.macosx.aarch64/forceQualifierUpdate.txt
@@ -1,3 +1,4 @@
 # To force a version qualifier update add the bug here
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1682

--- a/bundles/org.eclipse.swt.cocoa.macosx.x86_64/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.swt.cocoa.macosx.x86_64/forceQualifierUpdate.txt
@@ -3,3 +3,4 @@ Bug 434039 - SWT fragment source is not always included in SDK or repository
 Bug 436000 - Comparator errors in I20140527-2000 build
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1682

--- a/bundles/org.eclipse.swt.gtk.linux.aarch64/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.swt.gtk.linux.aarch64/forceQualifierUpdate.txt
@@ -2,3 +2,4 @@
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1608
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1682

--- a/bundles/org.eclipse.swt.gtk.linux.ppc64le/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.swt.gtk.linux.ppc64le/forceQualifierUpdate.txt
@@ -3,3 +3,4 @@ Bug 434039 - SWT fragment source is not always included in SDK or repository
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1608
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1682

--- a/bundles/org.eclipse.swt.gtk.linux.x86_64/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.swt.gtk.linux.x86_64/forceQualifierUpdate.txt
@@ -3,3 +3,4 @@ Bug 434039 - SWT fragment source is not always included in SDK or repository
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1608
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1682

--- a/bundles/org.eclipse.swt.win32.win32.x86_64/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.swt.win32.win32.x86_64/forceQualifierUpdate.txt
@@ -3,3 +3,4 @@ Bug 434039 - SWT fragment source is not always included in SDK or repository
 Bug 436000 - Comparator errors in I20140527-2000 build
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1682


### PR DESCRIPTION
See https://github.com/eclipse-platform/eclipse.platform.swt/pull/947

Fixes https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1682